### PR TITLE
na_ontap_info: call_api now returns all records

### DIFF
--- a/ansible_collections/netapp/ontap/README.md
+++ b/ansible_collections/netapp/ontap/README.md
@@ -25,10 +25,12 @@ Join our Slack Channel at [Netapp.io](http://netapp.io/slack)
 ## 20.4.0
 
 ### New Options
+- na_ontap_info: `max_records` option specifies maximum number of records returned in a single ZAPI call.
 - na_ontap_kerberos_realm: `ad_server_ip` option specifies IP Address of the Active Directory Domain Controller (DC).
 - na_ontap_kerberos_realm: `ad_server_name` option specifies Host name of the Active Directory Domain Controller (DC).
 
 ### Bug Fixes
+- na_ontap_info: return all records of each gathered subset.
 - na_ontap_kerberos_realm: fix `kdc_vendor` case sensitivity issue.
 
 ### New Modules

--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
@@ -112,7 +112,8 @@ options:
     max_records:
         type: int
         description:
-            - Maximum number of records per subset to return. Valid range is [1..2^32-1].
+            - Maximum number of records returned in a single ZAPI call. Valid range is [1..2^32-1].
+                This parameter controls internal behavior of this module.
         default: 1024
         version_added: '20.2.0'
 '''


### PR DESCRIPTION
##### SUMMARY
Since the very beginning of the existence of `na_ontap_gather_facts` and later `na_ontap_info` neither of those modules could return information of all resources present on ONTAP. For smaller installation this is barely visible. 

The parameter `max_records` even if set to the maximum value `2^32-1` would be always 'overridden' by what filer is able to produce in one batch thus in case of more than 1500 (this is from my experience, also shown below in `Additional Information` section) of any resources (volumes, snapshot, etc.) returned by *-get-iter it randomly returns number of records below 1500. In most of the cases this comes unnoticed.

Due to the nature of this module it is important to return everything and this PR fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_ontap_info

##### ADDITIONAL INFORMATION
call_api method has been enhanced so that for every zapi call it checks if next-tag field is set, it is processing all records, utilizing max_records that defines the number of records returned in each consecutive zapi *-get-iter or *-get call, until next-tag is no longer pointing to remaining records.

here original na_ontap_facts was run with max_records set to 1000000
```
$ jq  '.ontap_info.volume_info | keys | .[]'  before_fix_1st_run.json   | wc -l
1131 <- far too low
```
Second run produces different number of records still below expected 1945:
```
jq  '.ontap_info.volume_info | keys | .[]'  before_fix_2nd_run.json   | wc -l
1415 <- still too low
```
Corrected module, everything is returned:
```
$ jq  '.ontap_info.volume_info | keys | .[]'  after_fix.json   | wc -l
1945 <- expected
```

