### PR TITLE
Update na_ontap_export_policy_rule.py

### DIFF
--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy_rule.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_export_policy_rule.py
@@ -36,7 +36,7 @@ options:
 
   name:
     description:
-    - The name of the export rule to manage.
+    - The name of the export policy this rule will be added to.
     required: True
     type: str
     aliases:


### PR DESCRIPTION
in the "name:" paremeter in the module na_ontap_export_polcy_rule module the name given is the name of the POLICY the rule will be added to, not the name of the POLICY RULE. This was confusing, needed clarification.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
