### PR TITLE
Enhancement for the copy-paste people

### DIFF
--- a/ansible_collections/netapp/elementsw/README.md
+++ b/ansible_collections/netapp/elementsw/README.md
@@ -17,7 +17,7 @@ collections:
 # Need help
 Join our Slack Channel at [Netapp.io](http://netapp.io/slack)
 
-#Release Notes
+# Release Notes
 
 ## 20.10.0
 

--- a/ansible_collections/netapp/elementsw/plugins/modules/na_elementsw_snapshot_schedule.py
+++ b/ansible_collections/netapp/elementsw/plugins/modules/na_elementsw_snapshot_schedule.py
@@ -142,6 +142,7 @@ EXAMPLES = """
        schedule_type: TimeIntervalFrequency
        time_interval_days: 1
        starting_date: '2016-12-01T00:00:00Z'
+       retention: '24:00:00'
        volumes:
        - 7
        - test
@@ -157,6 +158,7 @@ EXAMPLES = """
        schedule_type: TimeIntervalFrequency
        time_interval_days: 1
        starting_date: '2016-12-01T00:00:00Z'
+       retention: '24:00:00'
        volumes:
        - 8
        - test1


### PR DESCRIPTION
##### SUMMARY

The current examples for SF snapshot_schedule correctly do not include a `retention` value.

But, without the optional `retention` value most any recurring schedule is bound to hit the Max # of Snaps within days or weeks. 
It seems better to have this in the sample in there for the copy-paste crowd. Some folks might even check the manuals and manage to avoid snapshot errors.

The SF Ansible module docs shouldn't repeat what's already clearly mentioned in the SF documentation and API Guide, but adding these two rows will serve as a reminder and improve outcomes for the folks who get started by modifying these examples.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- na_elementsw_snapshot_schedule.py 
