### PR TITLE
return image info by node

### DIFF
--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
@@ -429,7 +429,7 @@ class NetAppONTAPGatherInfo(object):
                 'method': self.get_generic_get_iter,
                 'kwargs': {
                     'call': 'cluster-image-get-iter',
-                    'attribute': 'cluster-image-info',
+                    'attribute': 'node-id',
                     'key_fields': 'current-version',
                     'query': {'max-records': self.max_records},
                 },

--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_info.py
@@ -429,8 +429,8 @@ class NetAppONTAPGatherInfo(object):
                 'method': self.get_generic_get_iter,
                 'kwargs': {
                     'call': 'cluster-image-get-iter',
-                    'attribute': 'node-id',
-                    'key_fields': 'current-version',
+                    'attribute': 'cluster-image-info',
+                    'key_fields': 'node-id',
                     'query': {'max-records': self.max_records},
                 },
                 'min_version': '0',


### PR DESCRIPTION
##### SUMMARY
cluster_image_info should return entries by node and not by cluster version otherwise they get merged into one if all nodes are running the same version. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_ontap_info

##### ADDITIONAL INFORMATION
With the latest release - 20.10.0 (as well as all past versions) cluster_image_info would return
```
ok: [cluser-fqdn] => {
    "msg": {
        "9.7P5": {
            "current_version": "9.7P5",
            "date_installed": "1599726442",
            "node_id": "node-02"
        }
    }
}
```
the fix
```
ok: [cluster-fqdn] => {
    "msg": {
        "node-01": {
            "current_version": "9.7P5",
            "date_installed": "1599726506",
            "node_id": "node-01"
        },
        "node-02": {
            "current_version": "9.7P5",
            "date_installed": "1599726442",
            "node_id": "node-02"
        }
    }
}

```
