### PR TITLE
na_sg_grid_account: new option root_access_group

### DIFF
--- a/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
+++ b/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
@@ -65,6 +65,11 @@ options:
     - Allows tenant to use platform services features such as CloudMirror.
     type: bool
     default: false
+  root_access_account:
+    description:
+    - Existing federated group to have initial Root Access permissions for the tenant.
+    type: str
+    default: false
   quota_size:
     description:
     - Quota to apply to the tenant specified in (quota_size_unit).
@@ -143,6 +148,7 @@ class SgGridAccount(object):
                 management=dict(required=False, type="bool", default=True),
                 use_own_identity_source=dict(required=False, type="bool"),
                 allow_platform_services=dict(required=False, type="bool"),
+                root_access_group=dict(required=False, type="str"),
                 quota_size=dict(required=False, type="int", default=0),
                 quota_size_unit=dict(
                     default="gb",
@@ -214,6 +220,9 @@ class SgGridAccount(object):
             self.data["policy"]["allowPlatformServices"] = self.parameters[
                 "allow_platform_services"
             ]
+
+        if self.parameters.get("root_access_group"):
+            self.data["grantRootAccessToGroup"] = self.parameters["root_access_group"]
 
         if self.parameters["quota_size"] > 0:
             self.parameters["quota_size"] = (

--- a/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
+++ b/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
@@ -65,7 +65,7 @@ options:
     - Allows tenant to use platform services features such as CloudMirror.
     type: bool
     default: false
-  root_access_account:
+  root_access_group:
     description:
     - Existing federated group to have initial Root Access permissions for the tenant.
     type: str

--- a/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
+++ b/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
@@ -69,7 +69,6 @@ options:
     description:
     - Existing federated group to have initial Root Access permissions for the tenant.
     type: str
-    default: false
   quota_size:
     description:
     - Quota to apply to the tenant specified in (quota_size_unit).
@@ -221,7 +220,7 @@ class SgGridAccount(object):
                 "allow_platform_services"
             ]
 
-        if self.parameters.get("root_access_group"):
+        if self.parameters.get("root_access_group") is not None:
             self.data["grantRootAccessToGroup"] = self.parameters["root_access_group"]
 
         if self.parameters["quota_size"] > 0:

--- a/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
+++ b/ansible_collections/netapp/storagegrid/plugins/modules/na_sg_grid_account.py
@@ -290,6 +290,9 @@ class SgGridAccount(object):
         if "password" in self.data:
             del self.data["password"]
 
+        if "grantRootAccessToGroup" in self.data:
+            del self.data["grantRootAccessToGroup"]
+
         response, error = self.rest_api.put(api, self.data)
         if error:
             self.module.fail_json(msg=error)


### PR DESCRIPTION
##### SUMMARY
Added new option "root_access_group" to the na_sg_grid_account module, which allows you to set an existing federated group to have initial root access to the tenant. 
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
na_sg_grid_account

##### ADDITIONAL INFORMATION