### PR TITLE
removed child args from NaElement adding error during return value

### DIFF
--- a/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
+++ b/ansible_collections/netapp/ontap/plugins/modules/na_ontap_command.py
@@ -171,11 +171,6 @@ class NetAppONTAPCommand(object):
         command_obj = netapp_utils.zapi.NaElement("system-cli")
 
         args_obj = netapp_utils.zapi.NaElement("args")
-        if self.return_dict:
-            args_obj.add_new_child('arg', 'set')
-            args_obj.add_new_child('arg', '-showseparator')
-            args_obj.add_new_child('arg', '"###"')
-            args_obj.add_new_child('arg', ';')
         for arg in self.command:
             args_obj.add_new_child('arg', arg)
         command_obj.add_child_elem(args_obj)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Removed child args from NaElement when return dict true as its causing errors in return values and has no impact on returning values as dict as parse_xml_to_dict function handles it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

before:

ok: [localhost] => {
    "output": {
        "changed": true,
        "failed": false,
        "msg": {
            "invoked_command": "version",
            "result_value": 1,
            "status": "passed",
            "stdout": "Error: \"set\" is not a recognized command\nNetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019\n",
            "stdout_lines": [
                "Error: \"set\" is not a recognized command",
                "NetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019"
            ],
            "stdout_lines_filter": [],
            "xml_dict": {
                "active_element": "",
                "cli-output": {
                    "attrs": {},
                    "data": "Error: \"set\" is not a recognized command\nNetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019\n"
                },
                "cli-result-value": {
                    "attrs": {},
                    "data": "'1'"
                },
                "last_element": "results",
                "results": {
                    "attrs": {
                        "status": "passed",
                        "xmlns": "http://www.netapp.com/filer/admin"
                    },
                    "data": ""
                }
            }
        }
    }
}


after:

ok: [localhost] => {
    "output": {
        "changed": true,
        "failed": false,
        "msg": {
            "invoked_command": "version",
            "result_value": 1,
            "status": "passed",
            "stdout": "'NetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019\n",
            "stdout_lines": [
                "'NetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019"
            ],
            "stdout_lines_filter": [],
            "xml_dict": {
                "active_element": "",
                "cli-output": {
                    "attrs": {},
                    "data": "'NetApp Release 9.6: Wed Jul 10 10:10:43 UTC 2019\n"
                },
                "cli-result-value": {
                    "attrs": {},
                    "data": "'1'"
                },
                "last_element": "results",
                "results": {
                    "attrs": {
                        "status": "passed",
                        "xmlns": "http://www.netapp.com/filer/admin"
                    },
                    "data": ""
                }
            }
        }
    }
}



```
